### PR TITLE
Resolve #77: Fix broken Google Maps API NoKey issue

### DIFF
--- a/views/details.hbs
+++ b/views/details.hbs
@@ -204,14 +204,13 @@
         </footer>    
 
         <script type="text/javascript" src="/javascripts/holder.js"></script>
-        <script type="text/javascript" src="/javascripts/googlemaps.js"></script>
         <script type="text/javascript" src="http://fastly.ink.sapo.pt/3.1.10/js/ink-all.js"></script>
         <script type="text/javascript" src="/javascripts/ink-all.min.js"></script>
         <script type="text/javascript" src="/javascripts/autoload.js"></script>
         <script src="http://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
         <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js" integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU=" crossorigin="anonymous"></script>
-        <script type="text/javascript" src="/javascripts/nokey.js"></script>
-        <script type="text/javascript" src="http://maps.google.com/maps/api/js?libraries=geometry&amp;sensor=false"></script>
+        <script type="text/javascript" src="/javascripts/googlemaps.js"></script>
+        <script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&key=AIzaSyD5HcWosMySGKaihhPx4dGRosKdxIybHpQ"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
 
         <script>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -230,8 +230,7 @@
         <script type="text/javascript" src="http://fastly.ink.sapo.pt/3.1.10/js/ink-all.js"></script>
         <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'></script>
         <script type="text/javascript" src="/javascripts/googlemaps.js"></script>
-        <script type="text/javascript" src="/javascripts/nokey.js"></script>
-        <script type="text/javascript" src="http://maps.google.com/maps/api/js?libraries=geometry&amp;sensor=false"></script>
+        <script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&key=AIzaSyD5HcWosMySGKaihhPx4dGRosKdxIybHpQ" async defer></script>
         <script src="http://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
         <script type="text/javascript" src="http://cdn.ink.sapo.pt/3.1.10/js/holder.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/ink/3.1.10/js/autoload.js"></script>

--- a/views/rides.hbs
+++ b/views/rides.hbs
@@ -206,7 +206,7 @@
         <script type="text/javascript" src="http://fastly.ink.sapo.pt/3.1.10/js/ink-all.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/ink/3.1.10/js/autoload.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/ink/3.1.10/js/modernizr-all.js"></script>
-        <script type="text/javascript" src="http://maps.google.com/maps/api/js?libraries=geometry&amp;sensor=false"></script>
+        <script src="https://maps.googleapis.com/maps/api/js?libraries=geometry&key=AIzaSyD5HcWosMySGKaihhPx4dGRosKdxIybHpQ" async defer></script>
         <script src="http://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
         <script type="text/javascript" src="/javascripts/googlemaps.js"></script>
         <script type="text/javascript" src="/javascripts/nokey.js"></script>


### PR DESCRIPTION
* Resolves critical broken Google Maps API NoKey issue across the entire site
* You can no longer run Google Maps on `localhost`, since the API key prohibits HTTP requests not with `stravawindanalysis.com` origin