### PR TITLE
Resolve #99: Change OAuth2.0 request scope to read from public

### DIFF
--- a/routes/login.js
+++ b/routes/login.js
@@ -3,7 +3,7 @@ const passport = require('passport');
 
 const router = express.Router();
 
-router.get('/', passport.authenticate('strava', { scope: ['public'] }), () => { });
+router.get('/', passport.authenticate('strava', { scope: ['read'] }), () => { });
 
 router.get('/callback',
   passport.authenticate('strava', { failureRedirect: '/login' }),


### PR DESCRIPTION
Formerly, the OAuth request using the `passport-strava-strategy` was using a scope of public. Instead, there was a security related change in the Strava V3 API that further broke down the permissions, and now that field is no longer valid.